### PR TITLE
docs: add link to the oficial site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# psichelpsite
+# psichelp.com.br
+
+> Acesse o site http://psichelp.com.br/ e saiba mais sobre o projeto.


### PR DESCRIPTION
Além disso, poderia colocar o link também na descrição do repositório. Hoje está vazio.